### PR TITLE
Simplify adoption: init command, install scripts, GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,35 +25,10 @@ jobs:
       - name: Run tests
         run: go test -race ./...
 
-      - name: Build binaries
-        run: |
-          VERSION=${GITHUB_REF_NAME}
-          COMMIT=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          LDFLAGS="-s -w -X github.com/bianoble/agent-sync/cmd/agent-sync/cmd.version=${VERSION} -X github.com/bianoble/agent-sync/cmd/agent-sync/cmd.commit=${COMMIT} -X github.com/bianoble/agent-sync/cmd/agent-sync/cmd.date=${DATE}"
-
-          mkdir -p dist
-
-          # Linux amd64
-          GOOS=linux GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/agent-sync-linux-amd64 ./cmd/agent-sync
-          # Linux arm64
-          GOOS=linux GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/agent-sync-linux-arm64 ./cmd/agent-sync
-          # macOS amd64
-          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/agent-sync-darwin-amd64 ./cmd/agent-sync
-          # macOS arm64
-          GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/agent-sync-darwin-arm64 ./cmd/agent-sync
-          # Windows amd64
-          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/agent-sync-windows-amd64.exe ./cmd/agent-sync
-
-      - name: Create checksums
-        run: |
-          cd dist
-          sha256sum * > checksums.txt
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          generate_release_notes: true
-          files: |
-            dist/agent-sync-*
-            dist/checksums.txt
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: agent-sync
+
+builds:
+  - main: ./cmd/agent-sync
+    binary: agent-sync
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/bianoble/agent-sync/cmd/agent-sync/cmd.version={{.Version}}
+      - -X github.com/bianoble/agent-sync/cmd/agent-sync/cmd.commit={{.ShortCommit}}
+      - -X github.com/bianoble/agent-sync/cmd/agent-sync/cmd.date={{.Date}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+# Homebrew tap — uncomment when bianoble/homebrew-agent-sync repo is created
+# and a HOMEBREW_TAP_TOKEN secret is added to the repository.
+#
+# brews:
+#   - repository:
+#       owner: bianoble
+#       name: homebrew-agent-sync
+#       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+#     homepage: https://github.com/bianoble/agent-sync
+#     description: Deterministic synchronization of agent files
+#     license: MIT
+#     install: |
+#       bin.install "agent-sync"
+#     test: |
+#       system "#{bin}/agent-sync", "version"

--- a/cmd/agent-sync/cmd/init.go
+++ b/cmd/agent-sync/cmd/init.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var initForce bool
+
+// initTemplate is the default agent-sync.yaml scaffold.
+// It includes a working git source example and commented-out alternatives.
+const initTemplate = `# agent-sync configuration
+# Docs: https://github.com/bianoble/agent-sync
+version: 1
+
+sources:
+  # Git repository (most common)
+  - name: team-rules
+    type: git
+    repo: https://github.com/your-org/agent-rules.git
+    ref: main
+    # paths:                  # optional: sync only these paths
+    #   - rules/
+
+  # Single file from a URL
+  # - name: security-policy
+  #   type: url
+  #   url: https://example.com/security.md
+  #   checksum: sha256:abc123...
+
+  # Local directory
+  # - name: local-rules
+  #   type: local
+  #   path: ./agents/rules/
+
+targets:
+  - source: team-rules
+    tools: [cursor, claude-code]
+    # Or use an explicit destination:
+    # destination: .cursor/rules/
+
+  # Built-in tools: cursor, claude-code, copilot, windsurf, cline, codex
+
+# variables:
+#   org: your-org
+#   env: production
+
+# transforms:
+#   - source: team-rules
+#     type: template
+#     vars:
+#       team: my-team
+
+# overrides:
+#   - target: .cursor/rules/intro.md
+#     strategy: prepend
+#     file: ./local/header.md
+
+# tool_definitions:
+#   - name: my-custom-tool
+#     destination: .my-tool/rules/
+`
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create a starter agent-sync.yaml configuration",
+	Long: `Creates an agent-sync.yaml file in the current directory with a well-commented
+template including a git source example and documented alternatives for URL and
+local sources.
+
+Use --force to overwrite an existing configuration file.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outPath := configPath
+		if !filepath.IsAbs(outPath) {
+			abs, err := filepath.Abs(outPath)
+			if err != nil {
+				return fmt.Errorf("resolving path: %w", err)
+			}
+			outPath = abs
+		}
+
+		if !initForce {
+			if _, err := os.Stat(outPath); err == nil {
+				return fmt.Errorf("%s already exists (use --force to overwrite)", outPath)
+			}
+		}
+
+		if err := os.WriteFile(outPath, []byte(initTemplate), 0644); err != nil {
+			return fmt.Errorf("writing config: %w", err)
+		}
+
+		info("Created %s", outPath)
+		info("")
+		info("Next steps:")
+		info("  1. Edit the file to point at your sources")
+		info("  2. Run 'agent-sync update' to resolve and lock")
+		info("  3. Run 'agent-sync sync' to write files to targets")
+		return nil
+	},
+}
+
+func init() {
+	initCmd.Flags().BoolVar(&initForce, "force", false, "overwrite existing config file")
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/agent-sync/cmd/init_test.go
+++ b/cmd/agent-sync/cmd/init_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestInitCreatesConfig(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "agent-sync.yaml")
+
+	// Override the global configPath used by the init command.
+	old := configPath
+	configPath = outPath
+	defer func() { configPath = old }()
+
+	initForce = false
+	err := initCmd.RunE(initCmd, nil)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("config file is empty")
+	}
+}
+
+func TestInitRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "agent-sync.yaml")
+
+	if err := os.WriteFile(outPath, []byte("existing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := configPath
+	configPath = outPath
+	defer func() { configPath = old }()
+
+	initForce = false
+	err := initCmd.RunE(initCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when file exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists': %v", err)
+	}
+}
+
+func TestInitForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "agent-sync.yaml")
+
+	if err := os.WriteFile(outPath, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := configPath
+	configPath = outPath
+	defer func() { configPath = old }()
+
+	initForce = true
+	err := initCmd.RunE(initCmd, nil)
+	if err != nil {
+		t.Fatalf("init --force: %v", err)
+	}
+
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "old content" {
+		t.Error("file was not overwritten")
+	}
+}
+
+func TestInitTemplateIsValidYAML(t *testing.T) {
+	var out map[string]any
+	if err := yaml.Unmarshal([]byte(initTemplate), &out); err != nil {
+		t.Fatalf("template is not valid YAML: %v", err)
+	}
+	if out["version"] == nil {
+		t.Error("template should contain 'version'")
+	}
+}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,27 @@
 # Installation
 
+## Quick Install (macOS / Linux)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/bianoble/agent-sync/main/install.sh | sh
+```
+
+This auto-detects your OS and architecture, downloads the latest release, verifies the SHA256 checksum, and installs to `/usr/local/bin` (or `~/.local/bin` if not writable).
+
+To install a specific version:
+
+```bash
+VERSION=v0.1.0 curl -sSL https://raw.githubusercontent.com/bianoble/agent-sync/main/install.sh | sh
+```
+
+## Quick Install (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/bianoble/agent-sync/main/install.ps1 | iex
+```
+
+Downloads the latest release, verifies the SHA256 checksum, installs to `%LOCALAPPDATA%\agent-sync\bin`, and adds it to your PATH.
+
 ## Pre-built Binaries
 
 Download the latest release from [GitHub Releases](https://github.com/bianoble/agent-sync/releases).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ This auto-detects your OS and architecture, downloads the latest release, verifi
 To install a specific version:
 
 ```bash
-VERSION=v0.1.0 curl -sSL https://raw.githubusercontent.com/bianoble/agent-sync/main/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/bianoble/agent-sync/main/install.sh | VERSION=v0.1.0 sh
 ```
 
 ## Quick Install (Windows)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,9 +2,13 @@
 
 This guide walks through setting up agent-sync in a project.
 
-## 1. Create Configuration
+## 1. Initialize Configuration
 
-Create `agent-sync.yaml` in your project root:
+```bash
+agent-sync init
+```
+
+This creates an `agent-sync.yaml` with a commented starter template. Open it and edit the source to point at your repository:
 
 ```yaml
 version: 1

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,6 +14,26 @@ These flags are available on all commands:
 
 ## Commands
 
+### init
+
+Create a starter `agent-sync.yaml` configuration file.
+
+```bash
+agent-sync init [--force]
+```
+
+- Writes a well-commented template with a git source example and documented alternatives
+- Respects the `--config` global flag for output path
+- Refuses to overwrite an existing file unless `--force` is given
+
+**Flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Overwrite existing config file |
+
+---
+
 ### sync
 
 Synchronize files to targets using the lockfile.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,119 @@
+# install.ps1 — install agent-sync on Windows
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/bianoble/agent-sync/main/install.ps1 | iex
+#
+# Environment variables:
+#   VERSION      — version to install (default: latest)
+#   INSTALL_DIR  — directory to install to (default: $env:LOCALAPPDATA\agent-sync\bin)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "bianoble/agent-sync"
+$Binary = "agent-sync"
+
+function Main {
+    $arch = Get-Arch
+
+    if ($env:VERSION) {
+        $version = $env:VERSION
+    } else {
+        $version = Get-LatestVersion
+    }
+
+    $versionDisplay = $version -replace "^v", ""
+    Write-Host "Installing $Binary v$versionDisplay (windows/$arch)"
+
+    if ($env:INSTALL_DIR) {
+        $installDir = $env:INSTALL_DIR
+    } else {
+        $installDir = Join-Path $env:LOCALAPPDATA "agent-sync\bin"
+    }
+
+    if (-not (Test-Path $installDir)) {
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    }
+
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "agent-sync-install-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+
+    try {
+        $archiveName = "${Binary}_windows_${arch}.zip"
+        $checksumsName = "checksums.txt"
+        $baseUrl = "https://github.com/$Repo/releases/download/$version"
+
+        Write-Host "Downloading $archiveName..."
+        Download-File "$baseUrl/$archiveName" (Join-Path $tmpDir $archiveName)
+        Download-File "$baseUrl/$checksumsName" (Join-Path $tmpDir $checksumsName)
+
+        Write-Host "Verifying checksum..."
+        Verify-Checksum $tmpDir $archiveName
+
+        Write-Host "Extracting..."
+        Expand-Archive -Path (Join-Path $tmpDir $archiveName) -DestinationPath $tmpDir -Force
+
+        $src = Join-Path $tmpDir "$Binary.exe"
+        $dest = Join-Path $installDir "$Binary.exe"
+        Copy-Item -Path $src -Destination $dest -Force
+
+        Write-Host "Installed $Binary to $dest"
+
+        # Add to PATH if not already present.
+        $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if ($userPath -notlike "*$installDir*") {
+            [Environment]::SetEnvironmentVariable("PATH", "$userPath;$installDir", "User")
+            $env:PATH = "$env:PATH;$installDir"
+            Write-Host "Added $installDir to user PATH"
+        }
+
+        Write-Host ""
+        & $dest version
+    } finally {
+        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-Arch {
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    switch ($arch) {
+        "AMD64" { return "amd64" }
+        "x86"   { return "amd64" } # 32-bit OS on 64-bit hardware
+        default { throw "Unsupported architecture: $arch" }
+    }
+}
+
+function Get-LatestVersion {
+    $url = "https://api.github.com/repos/$Repo/releases/latest"
+    $response = Invoke-RestMethod -Uri $url -UseBasicParsing
+    if (-not $response.tag_name) {
+        throw "Could not determine latest version from GitHub API"
+    }
+    return $response.tag_name
+}
+
+function Download-File($url, $dest) {
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+    } catch {
+        throw "Failed to download: $url"
+    }
+}
+
+function Verify-Checksum($dir, $file) {
+    $checksumsFile = Join-Path $dir "checksums.txt"
+    $checksums = Get-Content $checksumsFile
+    $entry = $checksums | Where-Object { $_ -match $file }
+
+    if (-not $entry) {
+        throw "Checksum not found for $file in checksums.txt"
+    }
+
+    $expected = ($entry -split "\s+")[0]
+    $actual = (Get-FileHash -Path (Join-Path $dir $file) -Algorithm SHA256).Hash.ToLower()
+
+    if ($actual -ne $expected) {
+        throw "Checksum mismatch for $file (expected $expected, got $actual)"
+    }
+}
+
+Main

--- a/install.ps1
+++ b/install.ps1
@@ -77,7 +77,7 @@ function Get-Arch {
     $arch = $env:PROCESSOR_ARCHITECTURE
     switch ($arch) {
         "AMD64" { return "amd64" }
-        "x86"   { return "amd64" } # 32-bit OS on 64-bit hardware
+        "x86"   { throw "32-bit Windows is not supported. A 64-bit system is required." }
         default { throw "Unsupported architecture: $arch" }
     }
 }
@@ -102,7 +102,7 @@ function Download-File($url, $dest) {
 function Verify-Checksum($dir, $file) {
     $checksumsFile = Join-Path $dir "checksums.txt"
     $checksums = Get-Content $checksumsFile
-    $entry = $checksums | Where-Object { $_ -match $file }
+    $entry = $checksums | Where-Object { $_.Contains($file) }
 
     if (-not $entry) {
         throw "Checksum not found for $file in checksums.txt"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+# install.sh — install agent-sync on macOS or Linux
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/bianoble/agent-sync/main/install.sh | sh
+#
+# Environment variables:
+#   VERSION      — version to install (default: latest)
+#   INSTALL_DIR  — directory to install to (default: /usr/local/bin or ~/.local/bin)
+
+set -eu
+
+REPO="bianoble/agent-sync"
+BINARY="agent-sync"
+
+main() {
+    need_cmd curl
+    need_cmd uname
+
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+
+    if [ -z "${VERSION:-}" ]; then
+        VERSION="$(get_latest_version)"
+    fi
+
+    # Strip leading v for display.
+    version_display="${VERSION#v}"
+    printf "Installing %s v%s (%s/%s)\n" "$BINARY" "$version_display" "$os" "$arch"
+
+    install_dir="${INSTALL_DIR:-}"
+    if [ -z "$install_dir" ]; then
+        if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
+            install_dir="/usr/local/bin"
+        else
+            install_dir="${HOME}/.local/bin"
+            mkdir -p "$install_dir"
+        fi
+    fi
+
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    archive_name="${BINARY}_${os}_${arch}.tar.gz"
+    checksums_name="checksums.txt"
+
+    base_url="https://github.com/${REPO}/releases/download/${VERSION}"
+
+    printf "Downloading %s...\n" "$archive_name"
+    download "${base_url}/${archive_name}" "${tmpdir}/${archive_name}"
+    download "${base_url}/${checksums_name}" "${tmpdir}/${checksums_name}"
+
+    printf "Verifying checksum...\n"
+    verify_checksum "$tmpdir" "$archive_name"
+
+    printf "Extracting...\n"
+    tar -xzf "${tmpdir}/${archive_name}" -C "$tmpdir"
+
+    install -m 755 "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}"
+    printf "Installed %s to %s/%s\n" "$BINARY" "$install_dir" "$BINARY"
+
+    # Verify the binary works.
+    if command -v "$BINARY" >/dev/null 2>&1; then
+        printf "\n"
+        "$BINARY" version
+    elif [ -x "${install_dir}/${BINARY}" ]; then
+        printf "\n"
+        "${install_dir}/${BINARY}" version
+        printf "\nNote: %s is not in your PATH. Add it with:\n" "$install_dir"
+        printf "  export PATH=\"%s:\$PATH\"\n" "$install_dir"
+    fi
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)  echo "linux" ;;
+        Darwin*) echo "darwin" ;;
+        *)       err "Unsupported OS: $(uname -s). Use install.ps1 for Windows." ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  echo "amd64" ;;
+        arm64|aarch64) echo "arm64" ;;
+        *)             err "Unsupported architecture: $(uname -m)" ;;
+    esac
+}
+
+get_latest_version() {
+    url="https://api.github.com/repos/${REPO}/releases/latest"
+    version="$(curl -sSL "$url" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+    if [ -z "$version" ]; then
+        err "Could not determine latest version from GitHub API"
+    fi
+    echo "$version"
+}
+
+download() {
+    url="$1"
+    dest="$2"
+    if ! curl -fsSL -o "$dest" "$url"; then
+        err "Failed to download: $url"
+    fi
+}
+
+verify_checksum() {
+    dir="$1"
+    file="$2"
+    expected="$(grep "$file" "${dir}/checksums.txt" | awk '{print $1}')"
+    if [ -z "$expected" ]; then
+        err "Checksum not found for $file in checksums.txt"
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "${dir}/${file}" | awk '{print $1}')"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 "${dir}/${file}" | awk '{print $1}')"
+    else
+        printf "Warning: no sha256sum or shasum found, skipping checksum verification\n"
+        return
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        err "Checksum mismatch for $file (expected $expected, got $actual)"
+    fi
+}
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "Required command not found: $1"
+    fi
+}
+
+err() {
+    printf "Error: %s\n" "$1" >&2
+    exit 1
+}
+
+main


### PR DESCRIPTION
## Summary
- Adds `agent-sync init` command that scaffolds a well-commented `agent-sync.yaml` with git/url/local source examples and all 6 built-in tools listed
- Adds `install.sh` (macOS/Linux) and `install.ps1` (Windows) one-liner install scripts with SHA256 checksum verification
- Adds `.goreleaser.yml` (v2) replacing the manual 5-platform build matrix in the release workflow
- Updates installation docs with quick-install sections, quickstart to use `init`, and CLI reference with the new command

## Test plan
- [x] `go test -race ./...` — all tests pass including 4 new init tests
- [x] `go vet ./...` — clean
- [x] `agent-sync init` creates valid YAML, refuses overwrite without `--force`, overwrites with `--force`
- [ ] CI lint passes
- [ ] `goreleaser check` validates `.goreleaser.yml` (requires goreleaser installed)
- [ ] `shellcheck install.sh` passes (requires shellcheck installed)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)